### PR TITLE
Use binary mode for file IO

### DIFF
--- a/serveBinAST.py
+++ b/serveBinAST.py
@@ -74,7 +74,7 @@ class MyHandler(BaseHTTPServer.BaseHTTPRequestHandler):
             self.send_header('Content-type', 'text/plain;charset=utf8')
 
         self.end_headers()
-        file_contents = open(path, 'r').read()
+        file_contents = open(path, 'rb').read()
         if accepts_gzip and SERVE_GZIP:
             file_contents = self.gzip_encode(file_contents)
 
@@ -82,7 +82,7 @@ class MyHandler(BaseHTTPServer.BaseHTTPRequestHandler):
 
     def gzip_encode(self, content):
         out = StringIO.StringIO()
-        gf = gzip.GzipFile(fileobj=out, mode='w', compresslevel=5)
+        gf = gzip.GzipFile(fileobj=out, mode='wb', compresslevel=5)
         gf.write(content)
         gf.close()
         return out.getvalue()


### PR DESCRIPTION
Without this, files were corrupted on Windows.

From Python docs:
> On Windows, 'b' appended to the mode opens the file in binary mode, so there are also modes like 'rb', 'wb', and 'r+b'. Python on Windows makes a distinction between text and binary files; the end-of-line characters in text files are automatically altered slightly when data is read or written. This behind-the-scenes modification to file data is fine for ASCII text files, but it’ll corrupt binary data like that in JPEG or EXE files. Be very careful to use binary mode when reading and writing such files. On Unix, it doesn’t hurt to append a 'b' to the mode, so you can use it platform-independently for all binary files.